### PR TITLE
Bug/fee spelling mistake

### DIFF
--- a/_data/api-commons/openapi.yaml
+++ b/_data/api-commons/openapi.yaml
@@ -2929,7 +2929,7 @@ paths:
               $ref: "#/definitions/fee"
       tags:
       - Services
-  /services/{service_id}/fees/{feed_id}/:
+  /services/{service_id}/fees/{fee_id}/:
     get:
       summary: Get Fee
       description: Get Fee
@@ -2943,7 +2943,7 @@ paths:
         - in: path
           required: true
           type: string
-          name: feed_id
+          name: fee_id
           description: 'The unique feed id.'
       responses:
         '200':
@@ -2967,7 +2967,7 @@ paths:
         - in: path
           required: true
           type: string
-          name: feed_id
+          name: fee_id
           description: 'The unique feed id.'
         - in: body
           name: body
@@ -2998,7 +2998,7 @@ paths:
         - in: path
           required: true
           type: string
-          name: feed_id
+          name: fee_id
           description: 'The unique feed id.'
       security:
         - appid: []


### PR DESCRIPTION
I found that `fee_id` was misspelled to `feed_id` in a couple places