### PR TITLE
minor fixes to types in definitions, to be in line with data spec

### DIFF
--- a/_data/api-commons/openapi.yaml
+++ b/_data/api-commons/openapi.yaml
@@ -4343,10 +4343,10 @@ disabilities.'
         type: string
       latitude:
         description: 'Y coordinate of location expressed in decimal degrees in WGS84 datum.'
-        type: string
+        type: number
       longitude:
         description: 'X coordinate of location expressed in decimal degrees in WGS84 datum.'
-        type: string
+        type: number
     required:
       - id
   organization:
@@ -4422,7 +4422,7 @@ disabilities.'
         type: string
       extension:
         description: 'The extension of the phone number.'
-        type: number
+        type: ['number', 'null']
       type:
         description: 'Whether the phone number relates to a fixed or cellular phone.'
         type: string


### PR DESCRIPTION
These fixes make the openapi yaml inline with the data spec on 
https://openreferral.readthedocs.io/en/latest/reference/#objects-and-fields
