### PR TITLE
added return of phone instead of contact for endpoint

### DIFF
--- a/_data/api-commons/openapi.yaml
+++ b/_data/api-commons/openapi.yaml
@@ -201,7 +201,7 @@ paths:
           description: The unique phone id.
       responses:
         '200':
-          description: Contact Response
+          description: Phone Response
           schema:
             type: array
             items:


### PR DESCRIPTION
Just a minor bug, the openapi was saying it should return a contact but it should be a phone.