### PR TITLE
fixed type error for lat long

### DIFF
--- a/_data/api-commons/openapi.yaml
+++ b/_data/api-commons/openapi.yaml
@@ -4343,10 +4343,10 @@ disabilities.'
         type: string
       latitude:
         description: 'Y coordinate of location expressed in decimal degrees in WGS84 datum.'
-        type: number
+        type: ['number', 'null']
       longitude:
         description: 'X coordinate of location expressed in decimal degrees in WGS84 datum.'
-        type: number
+        type: ['number', 'null']
     required:
       - id
   organization:


### PR DESCRIPTION
Found a similar error, where lat long should be nullable by the spec (https://openreferral.readthedocs.io/en/latest/reference/#location)
